### PR TITLE
Change headerStrickyHeight to open for override

### DIFF
--- a/Source/General/SegementSlideViewController.swift
+++ b/Source/General/SegementSlideViewController.swift
@@ -40,7 +40,7 @@ open class SegementSlideViewController: UIViewController {
     public var slideContentView: UIView {
         return segementSlideContentView
     }
-    public var headerStickyHeight: CGFloat {
+    open var headerStickyHeight: CGFloat {
         let headerHeight = segementSlideHeaderView.frame.height
         if edgesForExtendedLayout.contains(.top) {
             return headerHeight - topLayoutLength


### PR DESCRIPTION
Allow `headerStickyHeight` to be overridden.
`headerStickyHeight` can determine the `y` position where segment slide stops scrolling.